### PR TITLE
Polygon Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,20 @@ WORKDIR ${WORKDIR}
 # add code from local checkout
 ADD . ${WORKDIR}
 
+# install required utilities
+RUN apt-get update && \
+    apt-get install -y vim curl
+
+# install node 6.x
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get install -y nodejs
+
+# move original node and symlink
+RUN mv /usr/local/bin/node /usr/local/bin/node.original
+
+RUN ln -s /usr/bin/nodejs /usr/local/bin/node
+
+
 # install npm dependencies
 RUN npm install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,22 +12,6 @@ WORKDIR ${WORKDIR}
 # add code from local checkout
 ADD . ${WORKDIR}
 
-# install required utilities
-RUN apt-get update && \
-    apt-get install -y vim curl
-
-# install node 6.x
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-    apt-get install -y nodejs
-
-# move original node and symlink
-RUN mv /usr/local/bin/node /usr/local/bin/node.original
-
-RUN ln -s /usr/bin/nodejs /usr/local/bin/node
-
-
-
-
 # install npm dependencies
 RUN npm install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,22 @@ WORKDIR ${WORKDIR}
 # add code from local checkout
 ADD . ${WORKDIR}
 
+# install required utilities
+RUN apt-get update && \
+    apt-get install -y vim curl
+
+# install node 6.x
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get install -y nodejs
+
+# move original node and symlink
+RUN mv /usr/local/bin/node /usr/local/bin/node.original
+
+RUN ln -s /usr/bin/nodejs /usr/local/bin/node
+
+
+
+
 # install npm dependencies
 RUN npm install
 

--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -91,11 +91,9 @@ function getHierarchies(id, properties) {
 
 }
 
-function getPolygonCoords(object){
-  if(_.get(object, 'geometry.coordinates')){
-    if(object.geometry.coordinates.length === 1 && object.geometry.coordinates[0][0].length > 1){
-      return object.geometry.coordinates[0][0];
-    }
+function getPolygonGeometry(object){
+  if(object.geometry.type === 'Polygon' || object.geometry.type === 'MultiPolygon'){
+    return object.geometry;
   }
 }
 
@@ -122,9 +120,9 @@ module.exports.create = function map_fields_stream() {
 
     //Check config for polygon flag
     if(config.imports.whosonfirst.polygons){
-      const coords = getPolygonCoords(json_object);
-      if(coords){
-        record.coordinates = coords;
+      const geometry = getPolygonGeometry(json_object);
+      if(geometry){
+        record.geometry = geometry;
       }
     }
     // use the QS altname if US county and available

--- a/src/peliasDocGenerators.js
+++ b/src/peliasDocGenerators.js
@@ -59,8 +59,8 @@ function setupDocument(record, hierarchy) {
   wofDoc.setCentroid({ lat: record.lat, lon: record.lon });
 
   //Only if coordinates are present
-  if (record.coordinates) {
-    wofDoc.setPolygon({coordinates: record.coordinates});
+  if (record.geometry) {
+    wofDoc.setPolygon(record.geometry);
   }
   // only set population if available
   if (record.population) {

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -659,7 +659,7 @@ tape('create', function(test) {
       new Document( 'whosonfirst', 'region', '1')
         .setName('default', 'record name')
         .setCentroid({ lat: 12.121212, lon: 21.212121 })
-        .setPolygon({'coordinates': wofRecords[1].geometry})
+        .setPolygon(wofRecords[1].geometry)
         .addParent( 'region', 'record name', '1', 'record abbreviation')
 
     ];

--- a/test/peliasDocGeneratorsTest.js
+++ b/test/peliasDocGeneratorsTest.js
@@ -634,7 +634,18 @@ tape('create', function(test) {
         lat: 12.121212,
         lon: 21.212121,
         place_type: 'region',
-        coordinates: [[0,1], [1,0], [0.5,1]]
+        geometry: {
+          'type': 'Polygon',
+          'coordinates': [
+              [
+                  [100.0, 0.0],
+                  [101.0, 0.0],
+                  [101.0, 1.0],
+                  [100.0, 1.0],
+                  [100.0, 0.0]
+              ]
+          ]
+        }
       }
     };
 
@@ -648,7 +659,7 @@ tape('create', function(test) {
       new Document( 'whosonfirst', 'region', '1')
         .setName('default', 'record name')
         .setCentroid({ lat: 12.121212, lon: 21.212121 })
-        .setPolygon({'coordinates': wofRecords[1].coordinates})
+        .setPolygon({'coordinates': wofRecords[1].geometry})
         .addParent( 'region', 'record name', '1', 'record abbreviation')
 
     ];


### PR DESCRIPTION
Fixes for multipolygons. Passes geojson from original WoF doc through to ES document for API result destination.

![image](https://user-images.githubusercontent.com/32872347/38061838-07002eee-32bf-11e8-81ba-b32c5023a4ab.png)

`Invalid parameter` error is now gone thanks to the addition of a sanitizer that determines `geometries` is a valid parameter.
